### PR TITLE
Move to Chef-Workstation

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Then, with the chef-workstation_$RELEASE_amd64.deb package in the same
 directory as the chef-workstation.SlackBuild script, run the script as
 root to convert the .deb to a Slackware .txz:
 
-RELEASE=0.2.16-1 ./chef-workstation.SlackBuild
+RELEASE=0.2.21-1 ./chef-workstation.SlackBuild
 
 Change the RELEASE value to the same release number as the package as
 needed.
@@ -28,7 +28,7 @@ needed.
 This will produce a Slackware compatible .txz package.  The exact
 version number in the package filename will depend on the version
 of Google Chrome found in the .deb package, but it will be something
-like:  chef-workstation-0.1.162-x86_64-1zakame.txz
+like:  chef-workstation-0.2.21-x86_64-1zakame.txz
 
 You'll find the output package in the /tmp directory.
 
@@ -36,7 +36,7 @@ You'll find the output package in the /tmp directory.
 Then, install the package (again as root):
 
 cd /tmp
-upgradepkg --install-new chef-workstation-0.2.16-x86_64-1zakame.txz
+upgradepkg --install-new chef-workstation-0.2.21-x86_64-1zakame.txz
 
 Do note that if you have an inspec package installed, this chef-workstation
 package will overwrite the /usr/bin/inspec symlink installed by the

--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Then, with the chef-workstation_$RELEASE_amd64.deb package in the same
 directory as the chef-workstation.SlackBuild script, run the script as
 root to convert the .deb to a Slackware .txz:
 
-RELEASE=0.1.162-1 ./chef-workstation.SlackBuild
+RELEASE=0.2.16-1 ./chef-workstation.SlackBuild
 
 Change the RELEASE value to the same release number as the package as
 needed.
@@ -36,7 +36,7 @@ You'll find the output package in the /tmp directory.
 Then, install the package (again as root):
 
 cd /tmp
-upgradepkg --install-new chef-workstation-0.1.162-x86_64-1zakame.txz
+upgradepkg --install-new chef-workstation-0.2.16-x86_64-1zakame.txz
 
 Do note that if you have an inspec package installed, this chef-workstation
 package will overwrite the /usr/bin/inspec symlink installed by the

--- a/README
+++ b/README
@@ -26,9 +26,9 @@ Change the RELEASE value to the same release number as the package as
 needed.
 
 This will produce a Slackware compatible .txz package.  The exact
-version number in the package filename will depend on the version
-of Google Chrome found in the .deb package, but it will be something
-like:  chef-workstation-0.2.21-x86_64-1zakame.txz
+version number in the package filename will depend on the version of
+Chef Workstation in the .deb package, but it will be something like:
+chef-workstation-0.2.21-x86_64-1zakame.txz
 
 You'll find the output package in the /tmp directory.
 

--- a/README
+++ b/README
@@ -1,26 +1,26 @@
-chefdk (Chef Development Kit)
+chef-workstation (Chef Workstation, successor to Chef Development Kit)
 -----------------------------
 
 (Adapted from Pat Volkerding's original google-chrome SlackBuild.)
 
-Here's how to install chefdk on Slackware.
+Here's how to install chef-workstation on Slackware.
 
 
-First, go to the chefdk site:
+First, go to the chef-workstation site:
 
-https://downloads.chef.io/chefdk
+https://downloads.chef.io/chef-workstation
 
-Click the download button for the Debian 8 release.
+Click the download button for the Ubuntu 16.04 release.
 
 
 Read and accept the license terms, and download the .deb package.
 
 
-Then, with the chefdk_$RELEASE_amd64.deb package in the same directory
-as the chefdk.SlackBuild script, run the script as root to
-convert the .deb to a Slackware .txz:
+Then, with the chef-workstation_$RELEASE_amd64.deb package in the same
+directory as the chef-workstation.SlackBuild script, run the script as
+root to convert the .deb to a Slackware .txz:
 
-RELEASE=2.5.3-1 ./chefdk.SlackBuild
+RELEASE=0.1.162-1 ./chef-workstation.SlackBuild
 
 Change the RELEASE value to the same release number as the package as
 needed.
@@ -28,7 +28,7 @@ needed.
 This will produce a Slackware compatible .txz package.  The exact
 version number in the package filename will depend on the version
 of Google Chrome found in the .deb package, but it will be something
-like:  chefdk-2.5.3-x86_64-1zakame.txz
+like:  chef-workstation-0.1.162-x86_64-1zakame.txz
 
 You'll find the output package in the /tmp directory.
 
@@ -36,14 +36,14 @@ You'll find the output package in the /tmp directory.
 Then, install the package (again as root):
 
 cd /tmp
-upgradepkg --install-new chefdk-2.5.3-x86_64-1zakame.txz
+upgradepkg --install-new chef-workstation-0.1.162-x86_64-1zakame.txz
 
-Do note that if you have an inspec package installed, this chefdk
+Do note that if you have an inspec package installed, this chef-workstation
 package will overwrite the /usr/bin/inspec symlink installed by the
 inspec package.
 
-chefdk 3 now ships with inspec 2, so the standalone inspec package can
-now be removed if previously installed.
+chef-workstation ships with inspec 2, so the standalone inspec package
+can now be removed if previously installed.
 
 
 Enjoy!  :-)

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.18.3-1}
+RELEASE=${RELEASE:-20.7.81-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.43-1}
+RELEASE=${RELEASE:-0.2.48-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.53-1}
+RELEASE=${RELEASE:-0.3.2-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -2,7 +2,7 @@
 
 # Copyright 2009-2010  Erik Hanson, Minneapolis, MN, USA
 # Copyright 2011, 2015  Patrick J. Volkerding, Sebeka, MN, USA
-# Copyright 2018-2019  Zak B. Elep, Makati, Manila, Philippines
+# Copyright 2018-2020  Zak B. Elep, Makati, Manila, Philippines
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.13.35-1}
+RELEASE=${RELEASE:-0.15.6-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-20.10.168-1}
+RELEASE=${RELEASE:-20.11.180-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-20.7.81-1}
+RELEASE=${RELEASE:-20.8.111-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -77,7 +77,7 @@ chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
 # Link binaries in /opt/chef-workstation/bin to /usr/bin:
-binaries="berks chef chef-analyze chef-apply chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
+binaries="berks chef chef-analyze chef-apply chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic hab inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
 mkdir -p "$PKG/usr/bin"
 for binary in $binaries; do
   ( cd "$PKG/usr/bin" || exit 1 ; ln -sf "../../opt/chef-workstation/bin/$binary" "$binary" )

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.4.1-1}
+RELEASE=${RELEASE:-0.8.7-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -77,7 +77,7 @@ chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
 # Link binaries in /opt/chef-workstation/bin to /usr/bin:
-binaries="berks chef chef-apply chef-client chef-resource-inspector chef-run chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
+binaries="berks chef chef-apply chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
 mkdir -p "$PKG/usr/bin"
 for binary in $binaries; do
   ( cd "$PKG/usr/bin" || exit 1 ; ln -sf "../../opt/chef-workstation/bin/$binary" "$binary" )

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-20.12.205-1}
+RELEASE=${RELEASE:-21.2.259-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -77,7 +77,7 @@ chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
 # Link binaries in /opt/chef-workstation/bin to /usr/bin:
-binaries="berks chef chef-analyze chef-apply chef-automate-collect chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic hab inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
+binaries="berks chef chef-analyze chef-apply chef-automate-collect chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic hab inspec kitchen knife ohai stove"
 mkdir -p "$PKG/usr/bin"
 for binary in $binaries; do
   ( cd "$PKG/usr/bin" || exit 1 ; ln -sf "../../opt/chef-workstation/bin/$binary" "$binary" )

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -85,8 +85,7 @@ for binary in $binaries; do
 done
 
 # Link experimental chef-workstation-app to /usr/bin:
-cwa_app_path="$PKG/opt/chef-workstation/components/chef-workstation-app/chef-workstation-app"
-ln -sf $cwa_app_path $PREFIX/bin
+( cd $PKG/usr/bin ; ln -sf ../../opt/chef-workstation/components/chef-workstation-app/chef-workstation-app chef-workstation-app )
 
 # Make sure top-level perms are correct:
 chmod 0755 .

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-20.8.111-1}
+RELEASE=${RELEASE:-20.9.158-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -77,7 +77,7 @@ chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
 # Link binaries in /opt/chef-workstation/bin to /usr/bin:
-binaries="berks chef chef-analyze chef-apply chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic hab inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
+binaries="berks chef chef-analyze chef-apply chef-automate-collect chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic hab inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
 mkdir -p "$PKG/usr/bin"
 for binary in $binaries; do
   ( cd "$PKG/usr/bin" || exit 1 ; ln -sf "../../opt/chef-workstation/bin/$binary" "$binary" )

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-20.11.180-1}
+RELEASE=${RELEASE:-20.12.205-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.15.6-1}
+RELEASE=${RELEASE:-0.17.5-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.17.5-1}
+RELEASE=${RELEASE:-0.18.3-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.16-1}
+RELEASE=${RELEASE:-0.2.21-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.8.7-1}
+RELEASE=${RELEASE:-0.9.42-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.48-1}
+RELEASE=${RELEASE:-0.2.53-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -2,7 +2,7 @@
 
 # Copyright 2009-2010  Erik Hanson, Minneapolis, MN, USA
 # Copyright 2011, 2015  Patrick J. Volkerding, Sebeka, MN, USA
-# Copyright 2018  Zak B. Elep, Makati, Manila, Philippines
+# Copyright 2018-2019  Zak B. Elep, Makati, Manila, Philippines
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.9.42-1}
+RELEASE=${RELEASE:-0.11.21-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -77,7 +77,7 @@ chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
 # Link binaries in /opt/chef-workstation/bin to /usr/bin:
-binaries="berks chef chef-apply chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
+binaries="berks chef chef-analyze chef-apply chef-cli chef-client chef-resource-inspector chef-run chef-service-manager chef-shell chef-solo chef-vault chef-windows-service cookstyle delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
 mkdir -p "$PKG/usr/bin"
 for binary in $binaries; do
   ( cd "$PKG/usr/bin" || exit 1 ; ln -sf "../../opt/chef-workstation/bin/$binary" "$binary" )

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.35-1}
+RELEASE=${RELEASE:-0.2.43-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.1.162-1}
+RELEASE=${RELEASE:-0.2.16-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -73,7 +73,7 @@ OUTPUT=${OUTPUT:-/tmp}
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $PKG
-ar p $CWD/chef-workstation_${RELEASE}_${DEBARCH}.deb data.tar.gz | tar xzv || exit 1
+ar p $CWD/chef-workstation_${RELEASE}_${DEBARCH}.deb data.tar.xz | tar xJv || exit 1
 chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
@@ -83,6 +83,10 @@ mkdir -p $PKG/usr/bin
 for binary in $binaries; do
   ( cd $PKG/usr/bin ; ln -sf ../../opt/chef-workstation/bin/$binary $binary )
 done
+
+# Link experimental chef-workstation-app to /usr/bin:
+cwa_app_path="$PKG/opt/chef-workstation/components/chef-workstation-app/chef-workstation-app"
+ln -sf $cwa_app_path $PREFIX/bin
 
 # Make sure top-level perms are correct:
 chmod 0755 .

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.3.2-1}
+RELEASE=${RELEASE:-0.4.1-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.21-1}
+RELEASE=${RELEASE:-0.2.29-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -31,14 +31,13 @@ RELEASE=${RELEASE:-0.2.29-1}
 # kernel:
 ARCH="x86_64"
 DEBARCH="amd64"
-LIBDIRSUFFIX="64"
 
 # Get the version from the Debian/Ubuntu .deb (thanks to Fred Richards):
-VERSION=$(ar p chef-workstation_${RELEASE}_${DEBARCH}.deb control.tar.gz 2> /dev/null | tar zxO ./control 2> /dev/null | grep Version | awk '{print $2}' | cut -d- -f1)
+VERSION=$(ar p "chef-workstation_${RELEASE}_${DEBARCH}.deb" control.tar.gz 2> /dev/null | tar zxO ./control 2> /dev/null | grep Version | awk '{print $2}' | cut -d- -f1)
 BUILD=${BUILD:-1zakame}
 
 
-if [ ! $UID = 0 ]; then
+if [ ! "$(id -u)" = 0 ]; then
   cat << EOF
 
 This script must be run as root.
@@ -70,29 +69,29 @@ OUTPUT=${OUTPUT:-/tmp}
 
 /bin/sha256sum -c chef-workstation.checksums || exit 1
 
-rm -rf $PKG
-mkdir -p $TMP $PKG $OUTPUT
-cd $PKG
-ar p $CWD/chef-workstation_${RELEASE}_${DEBARCH}.deb data.tar.xz | tar xJv || exit 1
+rm -rf "$PKG"
+mkdir -p "$TMP" "$PKG" "$OUTPUT"
+cd "$PKG" || exit 1
+ar p "$CWD/chef-workstation_${RELEASE}_${DEBARCH}.deb" data.tar.xz | tar xJv || exit 1
 chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
 # Link binaries in /opt/chef-workstation/bin to /usr/bin:
 binaries="berks chef chef-apply chef-client chef-resource-inspector chef-run chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
-mkdir -p $PKG/usr/bin
+mkdir -p "$PKG/usr/bin"
 for binary in $binaries; do
-  ( cd $PKG/usr/bin ; ln -sf ../../opt/chef-workstation/bin/$binary $binary )
+  ( cd "$PKG/usr/bin" || exit 1 ; ln -sf "../../opt/chef-workstation/bin/$binary" "$binary" )
 done
 
 # Link experimental chef-workstation-app to /usr/bin:
-( cd $PKG/usr/bin ; ln -sf ../../opt/chef-workstation/components/chef-workstation-app/chef-workstation-app chef-workstation-app )
+( cd "$PKG/usr/bin" || exit 1 ; ln -sf ../../opt/chef-workstation/components/chef-workstation-app/chef-workstation-app chef-workstation-app )
 
 # Make sure top-level perms are correct:
 chmod 0755 .
 
-mkdir -p $PKG/install
-cat $CWD/slack-desc > $PKG/install/slack-desc
+mkdir -p "$PKG/install"
+cat "$CWD/slack-desc" > "$PKG/install/slack-desc"
 
-cd $PKG
-/sbin/makepkg -l y -c n $OUTPUT/$PKGNAM-$VERSION-$ARCH-$BUILD.txz
+cd "$PKG" || exit 1
+/sbin/makepkg -l y -c n "$OUTPUT/$PKGNAM-$VERSION-$ARCH-$BUILD.txz"
 

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -23,8 +23,8 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-PKGNAM=chefdk
-RELEASE=${RELEASE:-3.1.0-1}
+PKGNAM=chef-workstation
+RELEASE=${RELEASE:-0.1.162-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64
@@ -34,7 +34,7 @@ DEBARCH="amd64"
 LIBDIRSUFFIX="64"
 
 # Get the version from the Debian/Ubuntu .deb (thanks to Fred Richards):
-VERSION=$(ar p chefdk_${RELEASE}_${DEBARCH}.deb control.tar.gz 2> /dev/null | tar zxO ./control 2> /dev/null | grep Version | awk '{print $2}' | cut -d- -f1)
+VERSION=$(ar p chef-workstation_${RELEASE}_${DEBARCH}.deb control.tar.gz 2> /dev/null | tar zxO ./control 2> /dev/null | grep Version | awk '{print $2}' | cut -d- -f1)
 BUILD=${BUILD:-1zakame}
 
 
@@ -47,14 +47,14 @@ EOF
   exit 1
 fi
 
-if ! /bin/ls chefdk_*.deb 1> /dev/null 2> /dev/null ; then
+if ! /bin/ls chef-workstation_*.deb 1> /dev/null 2> /dev/null ; then
   cat << EOF
 
-This is a script to repackage a chefdk .deb package
+This is a script to repackage a chef-workstation .deb package
 for Slackware.  Run this script in the same directory as this
 binary package:
 
-  chefdk_${RELEASE}_${DEBARCH}.deb
+  chef-workstation_${RELEASE}_${DEBARCH}.deb
 
 This will create a Slackware .txz package.  Install it with installpkg
 or use upgradepkg to upgrade from a previous version.
@@ -68,20 +68,20 @@ TMP=${TMP:-/tmp}
 PKG=$TMP/package-$PKGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-/bin/sha256sum -c chefdk.checksums || exit 1
+/bin/sha256sum -c chef-workstation.checksums || exit 1
 
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $PKG
-ar p $CWD/chefdk_${RELEASE}_${DEBARCH}.deb data.tar.gz | tar xzv || exit 1
+ar p $CWD/chef-workstation_${RELEASE}_${DEBARCH}.deb data.tar.gz | tar xzv || exit 1
 chown -R root:root .
 chmod -R u+w,go+r-w,a-s .
 
-# Link binaries in /opt/chefdk/bin to /usr/bin:
-binaries="berks chef chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
+# Link binaries in /opt/chef-workstation/bin to /usr/bin:
+binaries="berks chef chef-apply chef-client chef-resource-inspector chef-run chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai print_execution_environment push-apply pushy-client pushy-service-manager"
 mkdir -p $PKG/usr/bin
 for binary in $binaries; do
-  ( cd $PKG/usr/bin ; ln -sf ../../opt/chefdk/bin/$binary $binary )
+  ( cd $PKG/usr/bin ; ln -sf ../../opt/chef-workstation/bin/$binary $binary )
 done
 
 # Make sure top-level perms are correct:

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-20.9.158-1}
+RELEASE=${RELEASE:-20.10.168-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.11.21-1}
+RELEASE=${RELEASE:-0.13.35-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.SlackBuild
+++ b/chef-workstation.SlackBuild
@@ -24,7 +24,7 @@
 
 
 PKGNAM=chef-workstation
-RELEASE=${RELEASE:-0.2.29-1}
+RELEASE=${RELEASE:-0.2.35-1}
 
 # Allow $ARCH to be preset before running the script.  This is useful in the
 # case where someone is running a 32-bit chroot environment under an x86_64

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-d175c6dcc013bc48371ea3af740522309ba14a33feffdc115bca5136beb3264f chef-workstation_20.7.81-1_amd64.deb
+795f3550fa3a404fb57d1481edac7737d83e41cbca2af29b46adb833496dc3b6 chef-workstation_20.8.111-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-85bdbb7c4715f63c0bbb09b947303aa82dc5d77276c0994455ec5256fda24621 chef-workstation_20.11.180-1_amd64.deb
+e0b06ce6d471dfe7c48351c3b7b09b4866021efa2834036274d085b90c6fc7dd chef-workstation_20.12.205-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-0694b70fc774552580cc73f267bf299f348abd548d66f1f68262e589c98787fb chef-workstation_0.13.35-1_amd64.deb
+18893097c0e0363bdeca299c700780964350109f75daf9cfc86415322e5aeb7d chef-workstation_0.15.6-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-8d46113aed34323667369a95e85bb5f13888c3446c413ae8281834ccfa042db2 chef-workstation_0.2.29-1_amd64.deb
+f2c23e3d7c0eb1efe25361da404077f7ad757800026b46213d49018e14665b2e chef-workstation_0.2.35-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-69f07416dd832451556289d0a69d553ff35b3548a9aaa7338414f40de900a988 chef-workstation_20.9.158-1_amd64.deb
+3b11aafbea630e4837a980bf8501fe73a73cc7402a789612e759d3887c50d486 chef-workstation_20.10.168-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-070d4b788b8352f52446c7b1273f2bfcdd126ebcfee52878363b71add084e40a chef-workstation_0.9.42-1_amd64.deb
+13cade867ba9920619142c8503bb33678f1966c128ac0b03b98cc8876eabca36 chef-workstation_0.11.21-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-e0b06ce6d471dfe7c48351c3b7b09b4866021efa2834036274d085b90c6fc7dd chef-workstation_20.12.205-1_amd64.deb
+f980320918caacda4d12bb43d32e8693eaed82f999378d2b1a8fc9fd196d3e83 chef-workstation_21.2.259-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-3b11aafbea630e4837a980bf8501fe73a73cc7402a789612e759d3887c50d486 chef-workstation_20.10.168-1_amd64.deb
+85bdbb7c4715f63c0bbb09b947303aa82dc5d77276c0994455ec5256fda24621 chef-workstation_20.11.180-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-de4d171d034c477a8f590f27c7543c48346b56a57c6dccbdc0a3b416b831b94a chef-workstation_0.3.2-1_amd64.deb
+909bae8a87508887daf5cf580433cffaf058ae3b9994a2c6609af037ba73ff23 chef-workstation_0.4.1-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-5fae5098c8019b33117cc9bba6b44622649d9d90cb123b8ce9eeb741241fe1ce chef-workstation_0.2.16-1_amd64.deb
+1cf8d84779af170be8562b256c9a1ec1af6257b17e340d80831fa7f6b2ea8463 chef-workstation_0.2.21-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-1cf8d84779af170be8562b256c9a1ec1af6257b17e340d80831fa7f6b2ea8463 chef-workstation_0.2.21-1_amd64.deb
+8d46113aed34323667369a95e85bb5f13888c3446c413ae8281834ccfa042db2 chef-workstation_0.2.29-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-18893097c0e0363bdeca299c700780964350109f75daf9cfc86415322e5aeb7d chef-workstation_0.15.6-1_amd64.deb
+1df72f6278c577aecf3c1d0ccb027f80245c1e974d9667d295bde7130b17fdc8 chef-workstation_0.17.5-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,0 +1,2 @@
+# sha256 from https://downloads.chef.io/chef-workstation
+bd3aca707c9f66e5f810d44c61f67033e58e553a3d88e6619bfd708b19eccd20 chef-workstation_0.1.162-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-13cade867ba9920619142c8503bb33678f1966c128ac0b03b98cc8876eabca36 chef-workstation_0.11.21-1_amd64.deb
+0694b70fc774552580cc73f267bf299f348abd548d66f1f68262e589c98787fb chef-workstation_0.13.35-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-77e1a0372197f15d3a70b6c681ea7c529079cc9d860ad4ccf016b59bfba7abc1 chef-workstation_0.2.48-1_amd64.deb
+1de642d5d3a2e135edff05ff7c9a0d3b76496c35f9ea23f95d88e4b34df50f63 chef-workstation_0.2.53-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-bd3aca707c9f66e5f810d44c61f67033e58e553a3d88e6619bfd708b19eccd20 chef-workstation_0.1.162-1_amd64.deb
+5fae5098c8019b33117cc9bba6b44622649d9d90cb123b8ce9eeb741241fe1ce chef-workstation_0.2.16-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-1df72f6278c577aecf3c1d0ccb027f80245c1e974d9667d295bde7130b17fdc8 chef-workstation_0.17.5-1_amd64.deb
+51ff70d8e5e556df15ca22f344c65c36c41d44e0b416e98d7009764a59027512 chef-workstation_0.18.3-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-795f3550fa3a404fb57d1481edac7737d83e41cbca2af29b46adb833496dc3b6 chef-workstation_20.8.111-1_amd64.deb
+69f07416dd832451556289d0a69d553ff35b3548a9aaa7338414f40de900a988 chef-workstation_20.9.158-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-f2c23e3d7c0eb1efe25361da404077f7ad757800026b46213d49018e14665b2e chef-workstation_0.2.35-1_amd64.deb
+bfa180707eaa5ca6b539a005d3e4189f3f9b243d7fc5c145c1587850f592cfd1 chef-workstation_0.2.43-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-909bae8a87508887daf5cf580433cffaf058ae3b9994a2c6609af037ba73ff23 chef-workstation_0.4.1-1_amd64.deb
+7086dbfcff02666d54af8dd4e9ad5a803027c1326a6fcc1442674ba4780edb5a chef-workstation_0.8.7-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-7086dbfcff02666d54af8dd4e9ad5a803027c1326a6fcc1442674ba4780edb5a chef-workstation_0.8.7-1_amd64.deb
+070d4b788b8352f52446c7b1273f2bfcdd126ebcfee52878363b71add084e40a chef-workstation_0.9.42-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-1de642d5d3a2e135edff05ff7c9a0d3b76496c35f9ea23f95d88e4b34df50f63 chef-workstation_0.2.53-1_amd64.deb
+de4d171d034c477a8f590f27c7543c48346b56a57c6dccbdc0a3b416b831b94a chef-workstation_0.3.2-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-51ff70d8e5e556df15ca22f344c65c36c41d44e0b416e98d7009764a59027512 chef-workstation_0.18.3-1_amd64.deb
+d175c6dcc013bc48371ea3af740522309ba14a33feffdc115bca5136beb3264f chef-workstation_20.7.81-1_amd64.deb

--- a/chef-workstation.checksums
+++ b/chef-workstation.checksums
@@ -1,2 +1,2 @@
 # sha256 from https://downloads.chef.io/chef-workstation
-bfa180707eaa5ca6b539a005d3e4189f3f9b243d7fc5c145c1587850f592cfd1 chef-workstation_0.2.43-1_amd64.deb
+77e1a0372197f15d3a70b6c681ea7c529079cc9d860ad4ccf016b59bfba7abc1 chef-workstation_0.2.48-1_amd64.deb

--- a/chefdk.checksums
+++ b/chefdk.checksums
@@ -1,2 +1,0 @@
-# sha256 from https://downloads.chef.io/chefdk
-6c897581b151204b5ee28a905384a12e79fbe66445922cac5645d45fc3c23cd5 chefdk_3.1.0-1_amd64.deb

--- a/slack-desc
+++ b/slack-desc
@@ -5,15 +5,15 @@
 # make exactly 11 lines for the formatting to be correct.  It's also
 # customary to leave one space after the ':'.
 
-      |-----handy-ruler----------------------------------------------------|
-chefdk: chefdk (Chef Development Kit)
-chefdk:
-chefdk: The Chef Development Kit is a package that contains everything that
-chefdk: is needed to start using Chef, including chef-client and ohai; chef
-chefdk: and knife command line tools; testing tools such as Test Kitchen,
-chefdk: ChefSpec, Cookstyle, and Foodcritic; Inspec; and everything else
-chefdk: needed to author cookbooks and upload them to the Chef server.
-chefdk:
-chefdk:
-chefdk: Homepage:  https://docs.chef.io/about_chefdk.html
-chefdk:
+                |-----handy-ruler----------------------------------------------------|
+chef-workstation: chef-workstation (Chef Workstation)
+chef-workstation:
+chef-workstation: The Chef Workstation is the successor to the Chef Development Kit,
+chef-workstation: a package that contains everything that is needed to start using
+chef-workstation: Chef, including chef-client and ohai; chef and knife command line
+chef-workstation: tools; testing tools such as Test Kitchen, ChefSpec, Cookstyle,
+chef-workstation: and Foodcritic; Inspec; chef-run for ad-hoc remote execution,
+chef-workstation: and everything else needed to author cookbooks and upload them to
+chef-workstation: the Chef server.
+chef-workstation:
+chef-workstation: Homepage:  https://www.chef.sh


### PR DESCRIPTION
[Chef Workstation](https://www.chef.sh) has been out for a couple of years now, so probably it is best to move towards that as I've not experienced any problems packaging this upgrade to ChefDK.